### PR TITLE
Hotfix: Setup a training scene will not remove the camera if it is part of another object TRNG-804

### DIFF
--- a/Editor/SceneSetup/InteractionFrameworkSceneSetup.cs
+++ b/Editor/SceneSetup/InteractionFrameworkSceneSetup.cs
@@ -19,7 +19,7 @@ namespace Innoactive.CreatorEditor.BasicInteraction
         /// </summary>
         protected void RemoveMainCamera()
         {
-            if (Camera.main != null)
+            if (Camera.main != null && Camera.main.transform.parent == null)
             {
                 Object.DestroyImmediate(Camera.main.gameObject);
             }


### PR DESCRIPTION
### Description:

- chg: MainCamera will not be removed when Setup if it is part of another object.