### PR TITLE
Feature/validation for snapzones

### DIFF
--- a/Runtime/Validation.meta
+++ b/Runtime/Validation.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1188563dee9e4502a7f196a74dd0f00c
+timeCreated: 1598539296

--- a/Runtime/Validation/IsTrainingSceneObjectValidation.cs
+++ b/Runtime/Validation/IsTrainingSceneObjectValidation.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using Innoactive.Creator.Core.SceneObjects;
+using UnityEngine;
+
+namespace Innoactive.Creator.BasicInteraction.Validation
+{
+    /// <summary>
+    /// Checks if the training scene object attached to the given GameObject is listed as accepted trainin scene object.
+    /// </summary>
+    public class IsTrainingSceneObjectValidation : Validator
+    {
+        [SerializeField]
+        [Tooltip("All listed Training Scene Objects are valid to be snapped other will be rejected.")]
+        private TrainingSceneObject[] acceptedTrainingSceneObjects = {};
+
+        /// <summary>
+        /// Adds a new TrainingSceneObject to the list.
+        /// </summary>
+        public void AddTrainingSceneObject(TrainingSceneObject target)
+        {
+            if (acceptedTrainingSceneObjects.Contains(target) == false)
+            {
+                acceptedTrainingSceneObjects = acceptedTrainingSceneObjects.Append(target).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Removes an existing training scene object from the list.
+        /// </summary>
+        public void RemoveTrainingSceneObject(TrainingSceneObject target)
+        {
+            if (acceptedTrainingSceneObjects.Contains(target))
+            {
+                acceptedTrainingSceneObjects = acceptedTrainingSceneObjects.Where((obj => obj != target)).ToArray();
+            }
+        }
+        
+        /// <inheritdoc />
+        public override bool Validate(GameObject obj)
+        {
+            TrainingSceneObject trainingSceneObject = obj.GetComponent<TrainingSceneObject>();
+
+            if (trainingSceneObject == null)
+            {
+                return false;
+            }
+            
+            if (acceptedTrainingSceneObjects.Length == 0)
+            {
+                return true;
+            }
+            
+            return acceptedTrainingSceneObjects.Contains(trainingSceneObject);
+        }
+    }
+}

--- a/Runtime/Validation/IsTrainingSceneObjectValidation.cs.meta
+++ b/Runtime/Validation/IsTrainingSceneObjectValidation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 557aaed036734781b129d67ec56c9366
+timeCreated: 1598538729

--- a/Runtime/Validation/Validator.cs
+++ b/Runtime/Validation/Validator.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+
+namespace Innoactive.Creator.BasicInteraction.Validation
+{
+    /// <summary>
+    /// Base validator used to implement concrete validators.
+    /// </summary>
+    public abstract class Validator : MonoBehaviour
+    {
+        /// <summary>
+        /// When this returns true, the given object is allowed to be snapped.
+        /// </summary>
+        public abstract bool Validate(GameObject obj);
+
+        private void OnEnable()
+        {
+            // Has to be implemented to allow disabling this script.
+        }
+
+        private void OnDisable()
+        {
+            // Has to be implemented to allow disabling this script.
+        }
+    }
+}

--- a/Runtime/Validation/Validator.cs.meta
+++ b/Runtime/Validation/Validator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 91014cda39944f7892bbcc63709cdbd1
+timeCreated: 1598538333


### PR DESCRIPTION
### Description
Adds a basic validator for snapzones, which allows to only snap specific TrainingSceneObjects

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Test it with XR-Interactions