### PR TITLE
fix: interaction rig setup now uses concrete implementations

### DIFF
--- a/Runtime/RigSetup/InteractionRigSetup.cs
+++ b/Runtime/RigSetup/InteractionRigSetup.cs
@@ -130,7 +130,7 @@ namespace Innoactive.Creator.BasicInteraction.RigSetup
         
         private InteractionRigProvider FindAvailableInteractionRig()
         {
-            IEnumerable<InteractionRigProvider> availableRigs = ReflectionUtils.GetFinalImplementationsOf<InteractionRigProvider>()
+            IEnumerable<InteractionRigProvider> availableRigs = ReflectionUtils.GetConcreteImplementationsOf<InteractionRigProvider>()
                 .Select(type => (InteractionRigProvider) ReflectionUtils.CreateInstanceOfType(type))
                 .Where(provider => provider.CanBeUsed());
 


### PR DESCRIPTION
### Description
When overriding an existing Interaction Rig (e.g. XRRig) to add more logic or to adjust it for a template, the overridden one will not be shown anymore in the dropdown. Therefore, I changed it to Concrete Implementations instead of Final